### PR TITLE
refactor: use ubuntu:18.04 instead of centos:8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM  centos:8
+FROM  ubuntu:18.04
 LABEL maintainer="tech-ally@lacework.net" \
       description="The Lacework CLI helps you manage the Lacework cloud security platform"
 


### PR DESCRIPTION
The Lacework CLI is no longer running on CentOS 8 since it was deprecated https://github.com/lacework/go-sdk/pull/709